### PR TITLE
feat(charts/portals): add php-ini configmap

### DIFF
--- a/charts/portals/Chart.yaml
+++ b/charts/portals/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: portals
 description: Portals is a group allocation tool for the first week of the Department of Electrical Engineering and Information Technology at the FH Aachen - University of Applied Sciences.
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: "2.3.0"
 home: github.com/fsr5-fhaachen/portals
 maintainers:

--- a/charts/portals/templates/configmap.yaml
+++ b/charts/portals/templates/configmap.yaml
@@ -1,0 +1,6 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "portals.fullname" . }}
+data:
+  php.ini: {{- .Values.phpIni | toYaml | indent 2 }}

--- a/charts/portals/templates/deployment.yaml
+++ b/charts/portals/templates/deployment.yaml
@@ -45,6 +45,11 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          volumeMounts:
+            - name: configmap
+              mountPath: /usr/local/etc/php/php.ini
+              readOnly: true
+              subPath: php.ini
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -57,3 +62,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: configmap
+          configMap:
+            name: {{ include "portals.fullname" . }}

--- a/charts/portals/values.yaml
+++ b/charts/portals/values.yaml
@@ -87,3 +87,10 @@ migrateJob:
 
 disableReadinessProbe: false  # disable pod readiness probe (used for debugging)
 disableLivenessProbe: false  # disable pod liveness probe (used for debugging)
+
+phpIni: |
+  upload_max_filesize = 100M
+  post_max_size = 100M
+  memory_limit = 128M
+  max_execution_time = 300
+  max_input_time = 300


### PR DESCRIPTION
Implemented to adjust upload_max_filesize and other configuration values to allow upload of larger images. 

Configuration tested and working. 
